### PR TITLE
Replace deprecated configurations, configure duplicate strategy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,15 +7,16 @@ repositories {
 }
 
 dependencies {
-    compile 'net.portswigger.burp.extender:burp-extender-api:2.3'
-    compile 'com.google.code.gson:gson:2.8.2'
-    compile 'org.mongodb:mongo-java-driver:3.10.2'
-    compile 'org.mongodb:bson:3.10.2'
+    implementation 'net.portswigger.burp.extender:burp-extender-api:2.3'
+    implementation 'com.google.code.gson:gson:2.8.2'
+    implementation 'org.mongodb:mongo-java-driver:3.10.2'
+    implementation 'org.mongodb:bson:3.10.2'
 }
 
 task fatJar(type: Jar) {
     baseName = project.name + '-all'
-    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+    duplicatesStrategy = 'exclude'
+    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
 }
 


### PR DESCRIPTION
Before:

```
➜  burpsuite-project-file-parser git:(master) gradle --version

------------------------------------------------------------
Gradle 7.5.1
------------------------------------------------------------

Build time:   2022-08-05 21:17:56 UTC
Revision:     d1daa0cbf1a0103000b71484e1dbfe096e095918

Kotlin:       1.6.21
Groovy:       3.0.10
Ant:          Apache Ant(TM) version 1.10.11 compiled on July 10 2021
JVM:          17.0.4.1 (Homebrew 17.0.4.1+1)
OS:           Mac OS X 12.5.1 x86_64

➜  burpsuite-project-file-parser git:(master) java -version
openjdk version "18.0.2" 2022-07-19
OpenJDK Runtime Environment Homebrew (build 18.0.2+0)
OpenJDK 64-Bit Server VM Homebrew (build 18.0.2+0, mixed mode, sharing)
➜  burpsuite-project-file-parser git:(master) gradle fatJar

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/Maciej.Grela/repos/github.com/BuffaloWill/burpsuite-project-file-parser/build.gradle' line: 10

* What went wrong:
A problem occurred evaluating root project 'burpsuite-project-file-parser'.
> Could not find method compile() for arguments [net.portswigger.burp.extender:burp-extender-api:2.3] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 562ms
➜  burpsuite-project-file-parser git:(master)
```
After:

```
➜  burpsuite-project-file-parser git:(master) gradle fatJar

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.5.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 1s
2 actionable tasks: 2 executed
➜  burpsuite-project-file-parser git:(master) jar tvf build/libs/burpsuite-project-file-parser-all.jar | head -n 30
     0 Tue Oct 04 14:06:04 CEST 2022 META-INF/
    25 Tue Oct 04 14:06:04 CEST 2022 META-INF/MANIFEST.MF
     0 Thu Oct 28 15:09:50 CEST 2021 META-INF/maven/
     0 Thu Oct 28 15:09:50 CEST 2021 META-INF/maven/net.portswigger.burp.extender/
     0 Thu Oct 28 15:09:50 CEST 2021 META-INF/maven/net.portswigger.burp.extender/burp-extender-api/
   129 Thu Oct 28 15:09:50 CEST 2021 META-INF/maven/net.portswigger.burp.extender/burp-extender-api/pom.properties
  3311 Thu Oct 28 15:09:00 CEST 2021 META-INF/maven/net.portswigger.burp.extender/burp-extender-api/pom.xml
     0 Thu Oct 28 15:09:50 CEST 2021 burp/
   667 Thu Oct 28 15:09:50 CEST 2021 burp/IBurpCollaboratorClientContext.class
   327 Thu Oct 28 15:09:50 CEST 2021 burp/IBurpCollaboratorInteraction.class
   183 Thu Oct 28 15:09:50 CEST 2021 burp/IBurpExtender.class
  7019 Thu Oct 28 15:09:50 CEST 2021 burp/IBurpExtenderCallbacks.class
   295 Thu Oct 28 15:09:50 CEST 2021 burp/IContextMenuFactory.class
   995 Thu Oct 28 15:09:50 CEST 2021 burp/IContextMenuInvocation.class
   243 Thu Oct 28 15:09:50 CEST 2021 burp/ICookie.class
  1626 Thu Oct 28 15:09:50 CEST 2021 burp/IExtensionHelpers.class
   166 Thu Oct 28 15:09:50 CEST 2021 burp/IExtensionStateListener.class
   168 Thu Oct 28 15:09:50 CEST 2021 burp/IHttpHeader.class
   176 Thu Oct 28 15:09:50 CEST 2021 burp/IHttpListener.class
   461 Thu Oct 28 15:09:50 CEST 2021 burp/IHttpRequestResponse.class
   293 Thu Oct 28 15:09:50 CEST 2021 burp/IHttpRequestResponsePersisted.class
   312 Thu Oct 28 15:09:50 CEST 2021 burp/IHttpRequestResponseWithMarkers.class
   197 Thu Oct 28 15:09:50 CEST 2021 burp/IHttpService.class
   752 Thu Oct 28 15:09:50 CEST 2021 burp/IInterceptedProxyMessage.class
   201 Thu Oct 28 15:09:50 CEST 2021 burp/IIntruderAttack.class
   224 Thu Oct 28 15:09:50 CEST 2021 burp/IIntruderPayloadGenerator.class
   287 Thu Oct 28 15:09:50 CEST 2021 burp/IIntruderPayloadGeneratorFactory.class
   224 Thu Oct 28 15:09:50 CEST 2021 burp/IIntruderPayloadProcessor.class
   280 Thu Oct 28 15:09:50 CEST 2021 burp/IMenuItemHandler.class
   316 Thu Oct 28 15:09:50 CEST 2021 burp/IMessageEditor.class
```

This is my first ever gradle fix so be considerate ;).